### PR TITLE
Make out-of-bounds pad behavior consistent with openslide.

### DIFF
--- a/tiffslide/tests/test_tiffslide.py
+++ b/tiffslide/tests/test_tiffslide.py
@@ -227,3 +227,12 @@ def test_non_tiff_fallback(jpg_file):
     assert ts.get_thumbnail((10, 10))
     assert ts.associated_images == {}
     assert ts.read_region((0, 0), 0, (10, 10))
+
+
+def test_image_read_region_out_of_area(slide):
+    assert slide.read_region((-100, -100), 0, (50, 50), as_array=True, padding=True).shape[:2] == (50, 50)
+    assert slide.read_region((-100, -100), 100, (50, 50), as_array=True, padding=True).shape[:2] == (50, 50)
+    assert slide.read_region((-50, -50), 0, (100, 100), as_array=True, padding=True).shape[:2] == (100, 100)
+    with pytest.raises(AssertionError):
+        slide.read_region((-50, -50), 0, (50, 50), as_array=True, padding=False)
+    assert slide.read_region((-50, -50), 0, (100, 100), as_array=True, padding=False).shape[:2] == (50, 50)

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -415,19 +415,15 @@ class TiffSlide:
         rx1 = rx0 + _rw
         ry1 = ry0 + _rh
 
+        # dont use np.clip to avoid converting to np.int32 type.
+        clip = lambda x, _min, _max: min(max(x, _min), _max)
 
         # compute pad
-        pad_x0, pad_x1 = max(-rx0, 0), max(rx1-level_w, 0)
-        pad_y0, pad_y1 = max(-ry0, 0), max(ry1-level_h, 0)
-        #
-        pad_x0, pad_x1 = min(pad_x0, _rw), min(pad_x1, _rw)
-        pad_y0, pad_y1 = min(pad_y0, _rh), min(pad_y1, _rh)
+        pad_x0, pad_x1 = clip(-rx0, 0, _rw), clip(rx1-level_w, 0, _rw)
+        pad_y0, pad_y1 = clip(-ry0, 0, _rh), clip(ry1-level_h, 0, _rh)
         # crop coord to valid zone
-        rx0, rx1 = max(rx0, 0), min(rx1, level_w)
-        ry0, ry1 = max(ry0, 0), min(ry1, level_h)
-        #
-        rx1 = max(rx0, rx1)
-        ry1 = max(ry0, ry1)
+        rx0, rx1 = clip(rx0, 0, level_w), clip(rx1, 0, level_w)
+        ry0, ry1 = clip(ry0, 0, level_h), clip(ry1, 0, level_h)
         #
 
         if axes == "YXS":

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -396,6 +396,8 @@ class TiffSlide:
 
         axes = self.properties["tiffslide.series-axes"]
 
+        arr: npt.NDArray[np.int_]
+        
         if (level_h == -1 or level_w == -1) or \
                 (rx0 >= level_w or ry0 >= level_h) or \
                 (rx1 <= 0 or ry1 <= 0):
@@ -433,7 +435,6 @@ class TiffSlide:
             else:
                 raise NotImplementedError
 
-            arr: npt.NDArray[np.int_]
             if isinstance(self.ts_zarr_grp, zarr.core.Array):
                 arr = self.ts_zarr_grp[selection]
             else:


### PR DESCRIPTION
Fix #27 