### PR TITLE
Py37 compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   rev: 'v0.971'
   hooks:
   - id: mypy
-    additional_dependencies: ["numpy", "backports.cached_property"]
+    additional_dependencies: ["numpy"]
     exclude: ^examples/
 -   repo: https://github.com/PyCQA/flake8
     rev: '4.0.1'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-added-large-files
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.37.1
+  rev: v2.37.2
   hooks:
   - id: pyupgrade
     args: [--py37-plus]
@@ -20,7 +20,7 @@ repos:
   - id: black
     language_version: python3
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v0.961'
+  rev: 'v0.971'
   hooks:
   - id: mypy
     additional_dependencies: ["numpy", "backports.cached_property"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,7 @@ install_requires =
     fsspec
     pillow
     tifffile>=2020.9.22
-    zarr; python_version >= '3.8'
-    zarr<2.11.0; python_version < '3.8'
+    zarr
     backports.cached_property; python_version < '3.8'
     importlib_metadata; python_version < '3.8'
     typing_extensions; python_version < '3.10'

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,8 +38,8 @@ install_requires =
     pillow
     tifffile>=2020.9.22
     zarr
+    typing_extensions>=4.0
     backports.cached_property; python_version < '3.8'
-    typing_extensions; python_version < '3.10'
 
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     tifffile>=2020.9.22
     zarr
     typing_extensions>=4.0
-    backports.cached_property; python_version < '3.8'
 
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     tifffile>=2020.9.22
     zarr
     backports.cached_property; python_version < '3.8'
-    importlib_metadata; python_version < '3.8'
     typing_extensions; python_version < '3.10'
 
 

--- a/tiffslide/_pycompat.py
+++ b/tiffslide/_pycompat.py
@@ -28,20 +28,24 @@ __all__ = [
 
 def _requires_store_fix(ver_zarr: str, ver_tifffile: str) -> bool:
     _v_regex = re.compile(r"^([0-9]+)[.]([0-9]+)[.]([0-9]+)(a|b|rc)?([0-9]+)?$")
-    _v_map = {'a': 0, 'b': 1, 'rc': 2, None: 99}
+    _v_map = {"a": 0, "b": 1, "rc": 2, None: 99}
 
-    ver_zarr = [
-        int(x) if x and x.isdigit() else _v_map[x]
-        for x in _v_regex.match(ver_zarr).groups()
+    mz = _v_regex.match(ver_zarr)
+    mt = _v_regex.match(ver_tifffile)
+    if mz is None or mt is None:
+        return True
+
+    _ver_zarr: list[int] = [
+        int(x) if x and x.isdigit() else _v_map[x] for x in mz.groups()
     ]
-    ver_tifffile = [
-        int(x) if x and x.isdigit() else _v_map[x]
-        for x in _v_regex.match(ver_tifffile).groups()
+    _ver_tifffile: list[int] = [
+        int(x) if x and x.isdigit() else _v_map[x] for x in mt.groups()
     ]
 
-    _new_zarr = ver_zarr >= [2, 11, 0, 99, 99]
-    _old_tifffile = ver_tifffile < [2022, 3, 29, 99, 99]
+    _new_zarr = _ver_zarr >= [2, 11, 0, 99, 99]
+    _old_tifffile = _ver_tifffile < [2022, 3, 29, 99, 99]
     return _new_zarr and _old_tifffile
+
 
 REQUIRES_STORE_FIX = _requires_store_fix(zarr.__version__, tifffile_version)
 

--- a/tiffslide/_pycompat.py
+++ b/tiffslide/_pycompat.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 import sys
 from threading import RLock
 from typing import Any
+from typing import Callable
+from typing import Generic
 from typing import Iterator
 from typing import Mapping
+from typing import TypeVar
 
 import zarr
 from packaging.version import Version
@@ -68,12 +71,13 @@ def py37_fix_store(zstore: Mapping[str, Any]) -> Mapping[str, Any]:
 
 
 if sys.version_info < (3, 8):
-    # --- vendored cached_property from CPython ---------------------------
+    # --- vendored cached_property from CPython with added type information ---
 
+    _T = TypeVar("_T")
     _NOT_FOUND = object()
 
-    class cached_property:
-        def __init__(self, func):  # type: ignore
+    class cached_property(Generic[_T]):
+        def __init__(self, func: Callable[..., _T]) -> None:
             self.func = func
             self.attrname = None
             self.__doc__ = func.__doc__
@@ -88,9 +92,9 @@ if sys.version_info < (3, 8):
                     f"({self.attrname!r} and {name!r})."
                 )
 
-        def __get__(self, instance, owner=None):  # type: ignore
+        def __get__(self, instance: Any, owner: type[Any] | None = None) -> _T:
             if instance is None:
-                return self
+                return self  # type: ignore
             if self.attrname is None:
                 raise TypeError(
                     "Cannot use cached_property instance without calling __set_name__ on it."

--- a/tiffslide/_pycompat.py
+++ b/tiffslide/_pycompat.py
@@ -1,0 +1,126 @@
+"""python3.7 compatibility code
+
+This will be removed as soon as we drop python 3.7
+
+"""
+from __future__ import annotations
+
+import sys
+from threading import RLock
+from typing import Any
+from typing import Iterator
+from typing import Mapping
+
+import zarr
+from packaging.version import Version
+from tifffile import __version__ as tifffile_version
+
+__all__ = [
+    "REQUIRES_STORE_FIX",
+    "py37_fix_store",
+    "cached_property",
+]
+
+
+_new_zarr = Version(zarr.__version__) >= Version("2.11.0")
+_old_tifffile = Version(tifffile_version) < Version("2022.3.29")
+REQUIRES_STORE_FIX = _new_zarr and _old_tifffile
+
+
+# --- zarr - tifffile compatibility patches ---------------------------
+#
+# note: we can drop this once we drop python 3.7
+
+
+class _IncompatibleStoreShim(Mapping[str, Any]):
+    """
+    A compatibility shim, for python=3.7
+    with zarr>=2.11.0 with tifffile<2022.3.29
+    """
+
+    def __init__(self, mapping: Mapping[str, Any]) -> None:
+        self._m = mapping
+
+    def __getitem__(self, key: str) -> Any:
+        if key.endswith((".zarray", ".zgroup")) and key not in self._m:
+            raise KeyError(key)
+        try:
+            return self._m[key]
+        except ValueError:
+            raise KeyError(key)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._m)
+
+    def __len__(self) -> int:
+        return len(self._m)
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._m, item)
+
+
+def py37_fix_store(zstore: Mapping[str, Any]) -> Mapping[str, Any]:
+    """python 3.7 compatibility fix for tifffile and zarr"""
+    if REQUIRES_STORE_FIX:
+        return _IncompatibleStoreShim(zstore)
+    else:
+        return zstore
+
+
+if sys.version_info < (3, 8):
+    # --- vendored cached_property from CPython ---------------------------
+
+    _NOT_FOUND = object()
+
+    class cached_property:
+        def __init__(self, func):  # type: ignore
+            self.func = func
+            self.attrname = None
+            self.__doc__ = func.__doc__
+            self.lock = RLock()
+
+        def __set_name__(self, owner, name):  # type: ignore
+            if self.attrname is None:
+                self.attrname = name
+            elif name != self.attrname:
+                raise TypeError(
+                    "Cannot assign the same cached_property to two different names "
+                    f"({self.attrname!r} and {name!r})."
+                )
+
+        def __get__(self, instance, owner=None):  # type: ignore
+            if instance is None:
+                return self
+            if self.attrname is None:
+                raise TypeError(
+                    "Cannot use cached_property instance without calling __set_name__ on it."
+                )
+            try:
+                cache = instance.__dict__
+            except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
+                msg = (
+                    f"No '__dict__' attribute on {type(instance).__name__!r} "
+                    f"instance to cache {self.attrname!r} property."
+                )
+                raise TypeError(msg) from None
+            val = cache.get(self.attrname, _NOT_FOUND)
+            if val is _NOT_FOUND:
+                with self.lock:
+                    # check if another thread filled cache while we awaited lock
+                    val = cache.get(self.attrname, _NOT_FOUND)
+                    if val is _NOT_FOUND:
+                        val = self.func(instance)
+                        try:
+                            cache[self.attrname] = val
+                        except TypeError:
+                            msg = (
+                                f"The '__dict__' attribute on {type(instance).__name__!r} instance "
+                                f"does not support item assignment for caching {self.attrname!r} property."
+                            )
+                            raise TypeError(msg) from None
+            return val
+
+        # __class_getitem__ = classmethod(GenericAlias)
+
+else:
+    from functools import cached_property

--- a/tiffslide/_types.py
+++ b/tiffslide/_types.py
@@ -8,17 +8,20 @@ from typing import Any
 from typing import AnyStr
 from typing import Union
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 8):
     from typing import Protocol
-    from typing import TypeAlias
     from typing import TypedDict
     from typing import runtime_checkable
 
 else:
     from typing_extensions import Protocol
-    from typing_extensions import TypeAlias
     from typing_extensions import TypedDict
     from typing_extensions import runtime_checkable
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
     from types import TracebackType

--- a/tiffslide/tests/test_pycompat.py
+++ b/tiffslide/tests/test_pycompat.py
@@ -1,0 +1,16 @@
+import pytest
+
+from tiffslide._pycompat import _requires_store_fix
+
+
+@pytest.mark.parametrize(
+    "vz,vt,fix", [
+        ("2.11.0", "2022.3.29rc7", True),
+        ("2.10.1a3", "2022.3.29", False),
+        ("2.12.0", "2022.4.0", False),
+        ("2.13.0rc1", "2022.12.0", False),
+        ("2.11.3b1", "2022.2.11", True),
+    ]
+)
+def test_requires_fix(vz, vt, fix):
+    assert _requires_store_fix(vz, vt) == fix

--- a/tiffslide/tests/test_pycompat.py
+++ b/tiffslide/tests/test_pycompat.py
@@ -4,13 +4,14 @@ from tiffslide._pycompat import _requires_store_fix
 
 
 @pytest.mark.parametrize(
-    "vz,vt,fix", [
+    "vz,vt,fix",
+    [
         ("2.11.0", "2022.3.29rc7", True),
         ("2.10.1a3", "2022.3.29", False),
         ("2.12.0", "2022.4.0", False),
         ("2.13.0rc1", "2022.12.0", False),
         ("2.11.3b1", "2022.2.11", True),
-    ]
+    ],
 )
 def test_requires_fix(vz, vt, fix):
     assert _requires_store_fix(vz, vt) == fix

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -20,11 +20,9 @@ from xml.etree import ElementTree
 
 if sys.version_info[:2] >= (3, 8):
     from functools import cached_property
-    from importlib.metadata import version
     from typing import Literal
 else:
     from backports.cached_property import cached_property
-    from importlib_metadata import version
     from typing_extensions import Literal
 
 import numpy as np
@@ -71,7 +69,7 @@ __all__ = [
 
 # all relevant tifffile version numbers work with this.
 _TIFFFILE_VERSION = tuple(
-    int(x) if x.isdigit() else x for x in version("tifffile").split(".")
+    int(x) if x.isdigit() else x for x in tifffile.__version__.split(".")
 )
 
 # === Constants to support drop-in ===

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -22,7 +22,7 @@ if sys.version_info[:2] >= (3, 8):
     from functools import cached_property
     from typing import Literal
 else:
-    from backports.cached_property import cached_property
+    from tiffslide._pycompat import cached_property
     from typing_extensions import Literal
 
 import numpy as np


### PR DESCRIPTION
working towards making tiffslide a noarch package on conda-forge...

- [x] do not require to limit zarr version on 3.7 (provide shim for tifffile)
- [x] make typing_extensions a permanent dependency (until we reach `python_version>=3.10` 😅 )
- [ ] decide about cached_property on py3.7