### PR TITLE
Adds hamamatsu tags on slide properties for .ndpi

### DIFF
--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -788,18 +788,20 @@ class _PropertyParser:
 
         # collect hamamatsu tags
         tags = self._tf.series[0][0].tags
-        tag_map = {"65421":"hamamatsu.SourceLens", 
-                   "65422":"hamamatsu.XOffsetFromSlideCentre",
-                   "65423":"hamamatsu.YOffsetFromSlideCentre",
-                   "Model":'hamamatsu.Model'}
-        for tf_t, ts_t in  tag_map.items():
+        tag_map = {
+            "65421": "hamamatsu.SourceLens",
+            "65422": "hamamatsu.XOffsetFromSlideCentre",
+            "65423": "hamamatsu.YOffsetFromSlideCentre",
+            "Model": "hamamatsu.Model",
+        }
+        for tf_t, ts_t in tag_map.items():
             tag = tags.get(tf_t)
             if tag:
-                md[ts_t]=tag.value
+                md[ts_t] = tag.value
 
-        md[PROPERTY_NAME_VENDOR]='hamamatsu'
-        if 'hamamatsu.SourceLens' in md:
-            md[PROPERTY_NAME_OBJECTIVE_POWER]=md['hamamatsu.SourceLens']
+        md[PROPERTY_NAME_VENDOR] = "hamamatsu"
+        if "hamamatsu.SourceLens" in md:
+            md[PROPERTY_NAME_OBJECTIVE_POWER] = md["hamamatsu.SourceLens"]
 
         return md
 

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -781,7 +781,7 @@ class _PropertyParser:
 
     def parse_hamamatsu(self) -> dict[str, Any]:
         warn(
-            "partial hamamatsu-format metadata parsing has been implemented!",
+            "hamamatsu-format metadata parsing only partially implemented!",
             stacklevel=2,
         )
         md = self.parse_generic_tiff()

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -784,7 +784,14 @@ class _PropertyParser:
             "no special hamamatsu-format metadata parsing implemented yet!",
             stacklevel=2,
         )
-        return self.parse_generic_tiff()
+        md = self.parse_generic_tiff()
+        # collect hamamatsu tags
+        page0 = self._tf.series[0][0]
+        hamamatsu_tags = {}
+        for k,t in page0.tags.items():
+            hamamatsu_tags[f'hamamatsu.{t.name}'] = t.value
+        md.update(hamamatsu_tags)
+        return md
 
     def parse_generic_tiff(self) -> dict[str, Any]:
         # todo: need to handle more supported formats in the future

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -787,18 +787,19 @@ class _PropertyParser:
         md = self.parse_generic_tiff()
 
         # collect hamamatsu tags
-        page0 = self._tf.series[0][0]
-        hamamatsu_tags = {}
-        for k,t in page0.tags.items():
-            hamamatsu_tags[f'hamamatsu.{t.name}'] = t.value
-        md.update(hamamatsu_tags)
+        tags = self._tf.series[0][0].tags
+        tag_map = {"65421":"hamamatsu.SourceLens", 
+                   "65422":"hamamatsu.XOffsetFromSlideCentre",
+                   "65423":"hamamatsu.YOffsetFromSlideCentre",
+                   "Model":'hamamatsu.Model'}
+        for tf_t, ts_t in  tag_map.items():
+            tag = tags.get(tf_t)
+            if tag:
+                md[ts_t]=tag.value
 
-        # Update dict
         md[PROPERTY_NAME_VENDOR]='hamamatsu'
-        md[PROPERTY_NAME_OBJECTIVE_POWER]=md['hamamatsu.65421']
-        md['hamamatsu.SourceLens']=md['hamamatsu.65421']
-        md['hamamatsu.XOffsetFromSlideCentre']=md['hamamatsu.65422']
-        md['hamamatsu.YOffsetFromSlideCentre']=md['hamamatsu.65423']
+        if 'hamamatsu.SourceLens' in md:
+            md[PROPERTY_NAME_OBJECTIVE_POWER]=md['hamamatsu.SourceLens']
 
         return md
 

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -781,16 +781,25 @@ class _PropertyParser:
 
     def parse_hamamatsu(self) -> dict[str, Any]:
         warn(
-            "no special hamamatsu-format metadata parsing implemented yet!",
+            "partial hamamatsu-format metadata parsing has been implemented!",
             stacklevel=2,
         )
         md = self.parse_generic_tiff()
+
         # collect hamamatsu tags
         page0 = self._tf.series[0][0]
         hamamatsu_tags = {}
         for k,t in page0.tags.items():
             hamamatsu_tags[f'hamamatsu.{t.name}'] = t.value
         md.update(hamamatsu_tags)
+
+        # Update dict
+        md[PROPERTY_NAME_VENDOR]='hamamatsu'
+        md[PROPERTY_NAME_OBJECTIVE_POWER]=md['hamamatsu.65421']
+        md['hamamatsu.SourceLens']=md['hamamatsu.65421']
+        md['hamamatsu.XOffsetFromSlideCentre']=md['hamamatsu.65422']
+        md['hamamatsu.YOffsetFromSlideCentre']=md['hamamatsu.65423']
+
         return md
 
     def parse_generic_tiff(self) -> dict[str, Any]:


### PR DESCRIPTION
Hi,

I made a few modifications at the `parse_hamamatsu` function in order to add all the hamamatsu tags on the properties of a NDPI tiffslide.

The reason is that in order to properly map NDPA annotations on the slide, apart from the mpp two additional offset related tags are necessary. Specifically:

| Tag      | Description                       |
| ------  | ------------------------  |
| 65422 | XOffsetFromSlideCentre |
| 65423 | YOffsetFromSlideCentre |

(table retrieved from the OpenSlide format description [here](https://openslide.org/formats/hamamatsu/))

In this pull request I added these extra tags as additional properties of the tiffslide with a naming scheme as such:  
`md[f'hamamatsu.{tag.name}']=tag.value`