### PR TITLE
Add MIRAX fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ docs/build/**
 htmlcov/**
 *.egg-info/**
 
+.venv/
+venv/
+
 **/tests/data
 tiffslide/_version.py
 

--- a/tiffslide/_kerchunk.py
+++ b/tiffslide/_kerchunk.py
@@ -13,6 +13,7 @@ from collections import ChainMap
 from io import StringIO
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Union
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -118,7 +119,7 @@ def to_kerchunk(
 
 
 def from_kerchunk(
-    kc: KerchunkSpec,
+    kc: Union[KerchunkSpec, dict[str, Any]],
     *,
     urlpath: str | None = None,
     storage_options: dict[str, Any] | None = None,

--- a/tiffslide/tests/test_tiffslide.py
+++ b/tiffslide/tests/test_tiffslide.py
@@ -13,11 +13,18 @@ import pytest
 import tiffslide
 from tiffslide import TiffFileError
 from tiffslide import TiffSlide
+from tiffslide._kerchunk import from_kerchunk
+from tiffslide._mirax import Mirax
 
 
 @pytest.fixture
 def slide(wsi_file):
-    yield TiffSlide(wsi_file)
+    if wsi_file.suffix == ".mrxs":
+        mrxs = Mirax(wsi_file)
+        kc = mrxs.build_reference()
+        yield from_kerchunk(kc)
+    else:
+        yield TiffSlide(wsi_file)
 
 
 def test_image_detect_format(wsi_file):
@@ -107,10 +114,12 @@ def test_image_get_best_level_for_downsample(slide):
         assert lvl == lvl_new
 
 
+@pytest.mark.support_mirax
 def test_image_read_region(slide):
     assert slide.read_region((0, 0), 0, (2220, 2967)).size == (2220, 2967)
 
 
+@pytest.mark.support_mirax
 def test_image_read_region_as_array(slide):
     assert slide.read_region((0, 0), 0, (2220, 2967), as_array=True).shape[:2] == (
         2967,


### PR DESCRIPTION
The MIRAX fixture marks test with the "mirax" marker. By default all MIRAX tests are skipped. To enable a MIRAX test, add a "support_mirax" marker to a test.

Follow-up on https://github.com/bayer-science-for-a-better-life/tiffslide/pull/44#issuecomment-1371128784

> I would suggest to continue by adding a test_mirax.py file with tests for locally stored mirax files. They should all be available publicly, so that everyone can reproduce behaviour.