### PR TITLE
correct downsample

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ addopts = [
   "-p", "no:faulthandler",
   "-m", "not compat",
 ]
+markers = [
+  "compat",
+]
 
 [tool.isort]
 profile = "black"

--- a/tiffslide/tests/test_compatibility.py
+++ b/tiffslide/tests/test_compatibility.py
@@ -70,7 +70,11 @@ def matches(fn, vendor=None, filename=None, ext=None):
 
 @pytest.fixture(params=list(FILES))
 def file_name(request):
-    yield FILES[request.param]
+    f = FILES[request.param]
+    if not os.path.isfile(f):
+        pytest.xfail("missing local test file")
+    else:
+        yield f
 
 
 @pytest.fixture()

--- a/tiffslide/tests/test_compatibility.py
+++ b/tiffslide/tests/test_compatibility.py
@@ -7,6 +7,9 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+
+pytestmark = pytest.mark.compat
+
 OPENSLIDE_TESTDATA_DIR = os.getenv("OPENSLIDE_TESTDATA_DIR", None)
 _FILES = {
     "svs": [
@@ -42,12 +45,8 @@ _FILES = {
     ],
 }
 FILES = {}
-if OPENSLIDE_TESTDATA_DIR is None:
-    pytestmark = pytest.mark.skip
 
-else:
-    pytestmark = pytest.mark.compat  # type: ignore
-
+if OPENSLIDE_TESTDATA_DIR is not None:
     for key, fns in _FILES.items():
         for fn in fns:
             k = f"{key}-{fn.split('/')[1]}"
@@ -89,6 +88,10 @@ def os_slide(file_name):
     from openslide import OpenSlide
 
     yield OpenSlide(file_name)
+
+
+def test_openslide_testdata_dir_env():
+    assert os.getenv("OPENSLIDE_TESTDATA_DIR") is not None
 
 
 def test_dimensions(ts_slide, os_slide):

--- a/tiffslide/tests/test_compatibility.py
+++ b/tiffslide/tests/test_compatibility.py
@@ -1,5 +1,4 @@
 import itertools
-import math
 import os
 import warnings
 from pathlib import Path
@@ -125,11 +124,8 @@ def test_strict_subset_level_dimensions(ts_slide, os_slide):
 
 
 def test_strict_subset_level_downsamples(ts_slide, os_slide):
-    # test that all available tiffslide levels are in os_slide
-    for ds in ts_slide.level_downsamples:
-        assert any(
-            math.isclose(ds, x, rel_tol=1e-5) for x in os_slide.level_downsamples
-        )
+    # test that all available tiffslide downsamples are in os_slide
+    assert set(ts_slide.level_downsamples).issubset(os_slide.level_downsamples)
 
 
 def test_read_region_equality_level_min(ts_slide, os_slide, file_name):

--- a/tiffslide/tests/test_compatibility.py
+++ b/tiffslide/tests/test_compatibility.py
@@ -113,11 +113,7 @@ def test_level_downsamples(ts_slide, os_slide, file_name):
     if matches(file_name, vendor="hamamatsu"):
         pytest.xfail("'ndpi' no computed levels")
 
-    np.testing.assert_allclose(
-        ts_slide.level_downsamples,
-        os_slide.level_downsamples,
-        rtol=1e-5,
-    )
+    assert ts_slide.level_downsamples == os_slide.level_downsamples
 
 
 def test_strict_subset_level_dimensions(ts_slide, os_slide):

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -231,7 +231,10 @@ class TiffSlide:
     def level_downsamples(self) -> tuple[float, ...]:
         """return the downsampling factors of levels as a list"""
         w0, h0 = self.dimensions
-        return tuple(math.sqrt((w0 * h0) / (w * h)) for w, h in self.level_dimensions)
+        return tuple(
+            ((w0 / w) + (h0 / h)) / 2.0
+            for w, h in self.level_dimensions
+        )
 
     @cached_property
     def properties(self) -> dict[str, Any]:


### PR DESCRIPTION
This partially addresses #51

Fixing #51 requires more investigation in case we aim for pixel perfect compatibility with openslide.

This PR should stay open until read_region is fixed.

- [x] implement pixel comparison debug script
- [x] provide a few example tests on intermediate levels