### PR TITLE
setup.cfg: version limit fsspec

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     imagecodecs
-    fsspec
+    fsspec!=2022.11.0,!=2023.1.0
     pillow
     tifffile>=2021.6.14
     zarr


### PR DESCRIPTION
fsspec==2022.11.0 had a bug in ReferenceFileSystem causing issues with newer zarr versions.
fsspec==2023.1.0 is incompatible with python3.7

To guarantee a working installation for python3.7 for now, we exclude both, even though for python3.8+ only the first would be required. But this way it's consistent, and we can keep the conda package a noarch package without changes.