### PR TITLE
tiffslide.repair: provide workarounds for non-ascii desc

### DIFF
--- a/tiffslide/repair.py
+++ b/tiffslide/repair.py
@@ -1,0 +1,103 @@
+"""helpers for broken wsi"""
+from __future__ import annotations
+
+import functools
+import inspect
+import os
+import os.path
+import warnings
+from typing import Any
+
+import tifffile
+
+
+def fix_description_tag_encoding(
+    filename: str | os.PathLike[str],
+    *,
+    errors: str = "ignore",
+    no_dry_run: bool = False,
+) -> int:
+    """overwrites broken description tags"""
+    filename = os.path.expanduser(filename)
+    tf = tifffile.TiffFile(filename, mode="r+")
+
+    applied_fixes = False
+    for page in tf.pages:
+        try:
+            description_tag = page.tags["ImageDescription"]
+        except KeyError:
+            continue
+        value = description_tag.value
+        if isinstance(value, bytes) and value:
+            if not no_dry_run:
+                print("# would fix tag", description_tag)
+                print("- ", repr(value)[2:-1])
+                print("+ ", repr(value.decode(errors=errors).encode())[2:-1])
+            else:
+                print("# fixing tag", description_tag)
+                new_value = value.decode("ascii", errors=errors)
+                if len(new_value.encode()) > len(value):
+                    raise RuntimeError("fixed string is longer than original?")
+                description_tag.overwrite(new_value)
+            applied_fixes = True
+    if not applied_fixes:
+        print("# found no problems with description tag encoding")
+    elif applied_fixes and not no_dry_run:
+        print("\n# run the command again with `--no-dry-run` to apply fixes")
+        print("# PLEASE BACKUP THE ORIGINAL FILE BEFORE!")
+    return 0
+
+
+def monkey_patch_description_tag_encoding() -> None:
+    from tifffile.tifffile import TiffTags
+
+    original_valueof_method = TiffTags.valueof
+    if getattr(original_valueof_method, "__monkey_patched__", False):
+        return
+
+    sig = inspect.signature(original_valueof_method)
+    if "key" not in sig.parameters:
+        raise AssertionError("monkey patch won't work on this tifffile version")
+
+    @functools.wraps(original_valueof_method)
+    def patched_valueof(*args: Any, **kwargs: Any) -> Any:
+        ba = sig.bind(*args, **kwargs)
+        ba.apply_defaults()
+        value = original_valueof_method(*ba.args, **ba.kwargs)
+        if ba.arguments["key"] == 270 and isinstance(value, bytes):
+            value = value.decode(errors="ignore")
+        return value
+
+    patched_valueof.__monkey_patched__ = True  # type: ignore
+
+    warnings.warn(
+        "Monkey patching `tifffile.tifffile.TiffTags` to recover non-ascii description tags.\n"
+        "IT IS NOT RECOMMENDED TO USE THIS WORKAROUND to load files that contain non-ascii\n"
+        "characters in their image description tags. To fix the WSI File, please run:\n"
+        "$ python -m tiffslide.repair fix-description-tag-encoding <wsi-file>\n",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+    # monkey patch the TiffTags class
+    TiffTags.valueof = patched_valueof
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Collection of helper scripts for broken wsi files"
+    )
+    subparsers = parser.add_subparsers(required=True)
+
+    parser0 = subparsers.add_parser("fix-description-tag-encoding")
+    parser0.add_argument("filename", help="local filename for wsi")
+    parser0.add_argument("--no-dry-run", action="store_true", help="modify wsi")
+    parser0.set_defaults(func=fix_description_tag_encoding)
+
+    args = parser.parse_args()
+    kw = vars(args).copy()
+    del kw["func"]
+
+    raise SystemExit(args.func(**kw))

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -1041,6 +1041,11 @@ def _get_filename(obj: Any) -> str:
 
 def _check_page_description_encoding(page: TiffPage) -> str:
     """try to return the description tag of a tiffpage"""
+    value = page.description
+    if value:
+        return value
+
+    # value was empty, try to recover
     value = page.tags.valueof(270, default="")
 
     if isinstance(value, str):

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -596,6 +596,8 @@ def _prepare_tifffile(
                 stacklevel=3,
             )
 
+    _monkey_patch()
+
     if isinstance(fb, TiffFileIO):
         # provided an IO stream like instance
         _warn_unused_storage_options(st_kw)
@@ -759,7 +761,8 @@ class _PropertyParser:
         md = self.new_metadata()
 
         # parse metadata from description
-        desc = self._tf.pages[0].description
+        page = self._tf.pages[0]
+        desc = _check_page_description_encoding(page)
         md.update(_parse_metadata_aperio(desc))
         md["tiff.ImageDescription"] = desc
 
@@ -832,7 +835,8 @@ class _PropertyParser:
         md = self.new_metadata()
 
         # store the description
-        desc = self._tf.pages[0].description
+        page = self._tf.pages[0]
+        desc = _check_page_description_encoding(page)
         md["tiff.ImageDescription"] = desc
 
         md["tiffslide.series-index"] = 0  # use series 0
@@ -1033,3 +1037,51 @@ def _get_filename(obj: Any) -> str:
             return obj.filename or ""
         except AttributeError:
             return ""
+
+
+def _check_page_description_encoding(page: TiffPage) -> str:
+    """try to return the description tag of a tiffpage"""
+    value = page.tags.valueof(270, default="")
+
+    if isinstance(value, str):
+        return value
+
+    elif isinstance(value, bytes) and value:
+        raise TiffFileError(
+            "ImageDescription tag has incompatible encoding.\n"
+            "# Try setting the environment variable TIFFSLIDE_MONKEY_PATCH_NON_ASCII_DESCRIPTIONS=1\n"
+            "# Or better fix your original file by running:\n"
+            "$ python -m tiffslide.repair description-tag-encoding <WSI_FILENAME>",
+        )
+
+    else:
+        raise ValueError(f"unsupported description type: {type(value)!r}")
+
+
+# === monkey patching =================================================
+
+
+def _env2bool(value: str) -> bool:
+    """convert an environment variable to bool"""
+    if not isinstance(value, str):
+        raise TypeError(f"value must be of type str, got: {type(value).__name__}")
+    value = value.lower()
+    if value in {"yes", "true", "t", "y", "1"}:
+        return True
+    elif value in {"no", "false", "f", "n", "0", ""}:
+        return False
+    else:
+        raise ValueError(f"could not parse value: {value!r}")
+
+
+def _monkey_patch() -> None:
+    """applying monkey tiffslide patches if requested"""
+    if _env2bool(os.getenv("TIFFSLIDE_MONKEY_PATCH_NON_ASCII_DESCRIPTIONS", "")):
+        from tiffslide.repair import monkey_patch_description_tag_encoding
+
+        warn(
+            "TIFFSLIDE_MONKEY_PATCH_NON_ASCII_DESCRIPTIONS is active!",
+            RuntimeWarning,
+            stacklevel=4,
+        )
+        monkey_patch_description_tag_encoding()

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -1042,7 +1042,7 @@ def _get_filename(obj: Any) -> str:
 def _check_page_description_encoding(page: TiffPage) -> str:
     """try to return the description tag of a tiffpage"""
     value = page.description
-    if value:
+    if isinstance(value, str) and value:
         return value
 
     # value was empty, try to recover


### PR DESCRIPTION
Implements workarounds for non-ascii description files.

1. defaults to raising an error when encountering non-ascii descriptions
2. the error message recommends fixing the image description with provided CLI interface
3. also offers a monkey patch workaround for tifffile, which emits warnings to push the user towards fixing the original file.


Closes #65

#### option 1
```shell
# fix wsi-image via
python -m tiffslide.repair fix-description-tag-encoding test.tif
```

#### option 2
```shell
export TIFFSLIDE_MONKEY_PATCH_NON_ASCII_DESCRIPTIONS=1
python my_tiffslide_script.py
```

